### PR TITLE
Make sure Query#start_time and #end_time are datetimes

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -73,6 +73,12 @@ class QueryTest(unittest.TestCase):
         with self.assertRaises(twingly_search.TwinglyQueryException):
             q.start_time = "This is not a datetime object"
 
+    def test_query_where_start_time_is_set_to_none(self):
+        q = self._client.query()
+        q.start_time = datetime.now()
+        q.start_time = None
+        self.assertIsNone(q.start_time)
+
     def test_query_should_add_end_time(self):
         q = self._client.query()
         q.pattern = "spotify"
@@ -101,6 +107,12 @@ class QueryTest(unittest.TestCase):
         q = self._client.query()
         with self.assertRaises(twingly_search.TwinglyQueryException):
             q.end_time = "This is not a datetime object"
+
+    def test_query_where_end_time_is_set_to_none(self):
+        q = self._client.query()
+        q.end_time = datetime.now()
+        q.end_time = None
+        self.assertIsNone(q.end_time)
 
     def test_query_should_encode_url_parameters(self):
         q = self._client.query()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -68,6 +68,11 @@ class QueryTest(unittest.TestCase):
         q.end_time = dateutil.parser.parse("2012-12-28 09:01:22 -0800")
         self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28 17:01:22")
 
+    def test_query_when_start_time_is_not_a_datetime(self):
+        q = self._client.query()
+        with self.assertRaises(twingly_search.TwinglyQueryException):
+            q.start_time = "This is not a datetime object"
+
     def test_query_should_add_end_time(self):
         q = self._client.query()
         q.pattern = "spotify"
@@ -91,6 +96,11 @@ class QueryTest(unittest.TestCase):
         q.pattern = "spotify"
         q.end_time = dateutil.parser.parse("2012-12-28 09:01:22 +0800")
         self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28 01:01:22")
+
+    def test_query_when_end_time_is_not_a_datetime(self):
+        q = self._client.query()
+        with self.assertRaises(twingly_search.TwinglyQueryException):
+            q.end_time = "This is not a datetime object"
 
     def test_query_should_encode_url_parameters(self):
         q = self._client.query()

--- a/twingly_search/query.py
+++ b/twingly_search/query.py
@@ -95,10 +95,15 @@ class Query(object):
         if time is None:
             return ''
 
-        time_in_utc = time
-        if time.tzinfo is not None:
-            time_in_utc = time.astimezone(utc)
+        time_in_utc = self._time_to_utc(time)
+
         return time_in_utc.strftime(self.DATETIME_FORMAT)
+
+    def _time_to_utc(self, time):
+        if time.tzinfo is None:
+            return time
+
+        return time.astimezone(utc)
 
     def _assert_valid_time(self, time):
         if time is None:

--- a/twingly_search/query.py
+++ b/twingly_search/query.py
@@ -35,8 +35,26 @@ class Query(object):
         self.client = client
         self.pattern = ''
         self.language = ''
-        self.start_time = None
-        self.end_time = None
+        self._start_time = None
+        self._end_time = None
+
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @start_time.setter
+    def start_time(self, time):
+        self._assert_valid_time(time)
+        self._start_time = time
+
+    @property
+    def end_time(self):
+        return self._end_time
+
+    @end_time.setter
+    def end_time(self, time):
+        self._assert_valid_time(time)
+        self._end_time = time
 
     def url(self):
         """
@@ -68,21 +86,23 @@ class Query(object):
             'key': self.client.api_key,
             'searchpattern': self.pattern,
             'documentlang': self.language,
-            'ts': self._time_to_utc_string(self.start_time, "start_time"),
-            'tsTo': self._time_to_utc_string(self.end_time, "end_time"),
+            'ts': self._time_to_utc_string(self.start_time),
+            'tsTo': self._time_to_utc_string(self.end_time),
             'xmloutputversion': 2
         }
 
-    def _time_to_utc_string(self, time, attr_name):
-        if time is not None:
-            if isinstance(time, datetime.datetime):
-                time_in_utc = time
-                if time.tzinfo is not None:
-                    time_in_utc = time.astimezone(utc)
-                return time_in_utc.strftime(self.DATETIME_FORMAT)
-            elif isinstance(time, basestring):
-                return time
-            else:
-                return ''
-        else:
+    def _time_to_utc_string(self, time):
+        if time is None:
             return ''
+
+        time_in_utc = time
+        if time.tzinfo is not None:
+            time_in_utc = time.astimezone(utc)
+        return time_in_utc.strftime(self.DATETIME_FORMAT)
+
+    def _assert_valid_time(self, time):
+        if time is None:
+            return;
+
+        if not isinstance(time, datetime.datetime):
+            raise TwinglyQueryException("Not a datetime object")

--- a/twingly_search/query.py
+++ b/twingly_search/query.py
@@ -102,7 +102,7 @@ class Query(object):
 
     def _assert_valid_time(self, time):
         if time is None:
-            return;
+            return
 
         if not isinstance(time, datetime.datetime):
             raise TwinglyQueryException("Not a datetime object")


### PR DESCRIPTION
This makes the python client behave more like the ruby client.
- You can no longer assign a string to start_time or end_time
- When an object other than a datetime is assigned, an exception is raised.

close #22
