### PR TITLE
Minor fixes before release

### DIFF
--- a/tests/fixtures/vcr_cassettes/search_for_spotify_on_sv_blogs_from_query.json
+++ b/tests/fixtures/vcr_cassettes/search_for_spotify_on_sv_blogs_from_query.json
@@ -13,7 +13,7 @@
           "User-Agent": "Twingly Search Python Client/3.0.0"
         },
         "method": "GET",
-        "uri": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A10+lang%3A+sv&apiKey=<TWINGLY-API-KEY>"
+        "uri": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A10+lang%3Asv&apiKey=<TWINGLY-API-KEY>"
       },
       "response": {
         "body": {

--- a/tests/fixtures/vcr_cassettes/search_for_spotify_on_sv_blogs_using_query.json
+++ b/tests/fixtures/vcr_cassettes/search_for_spotify_on_sv_blogs_using_query.json
@@ -13,7 +13,7 @@
           "User-Agent": "Twingly Search Python Client/3.0.0"
         },
         "method": "GET",
-        "uri": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A20+lang%3A+en+start-date%3A+2017-03-09+18%3A03%3A43&apiKey=<TWINGLY-API-KEY>"
+        "uri": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A20+lang%3A+en+start-date%3A+2017-03-09T18%3A03%3A43Z&apiKey=<TWINGLY-API-KEY>"
       },
       "response": {
         "body": {
@@ -36,7 +36,7 @@
           "message": "OK",
           "code": 200
         },
-        "url": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A20+lang%3A+en+start-date%3A+2017-03-09+18%3A03%3A43&apiKey=<TWINGLY-API-KEY>"
+        "url": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A20+lang%3A+en+start-date%3A+2017-03-09T18%3A03%3A43Z&apiKey=<TWINGLY-API-KEY>"
       },
       "recorded_at": "2017-05-18T18:07:05"
     }

--- a/tests/fixtures/vcr_cassettes/search_for_spotify_on_sv_blogs_using_query.json
+++ b/tests/fixtures/vcr_cassettes/search_for_spotify_on_sv_blogs_using_query.json
@@ -13,7 +13,7 @@
           "User-Agent": "Twingly Search Python Client/3.0.0"
         },
         "method": "GET",
-        "uri": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A20+lang%3A+en+start-date%3A+2017-03-09T18%3A03%3A43Z&apiKey=<TWINGLY-API-KEY>"
+        "uri": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A20+lang%3Aen+start-date%3A2017-03-09T18%3A03%3A43Z&apiKey=<TWINGLY-API-KEY>"
       },
       "response": {
         "body": {
@@ -36,7 +36,7 @@
           "message": "OK",
           "code": 200
         },
-        "url": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A20+lang%3A+en+start-date%3A+2017-03-09T18%3A03%3A43Z&apiKey=<TWINGLY-API-KEY>"
+        "url": "https://api.twingly.com/blog/search/api/v3/search?q=spotify+page-size%3A20+lang%3Aen+start-date%3A2017-03-09T18%3A03%3A43Z&apiKey=<TWINGLY-API-KEY>"
       },
       "recorded_at": "2017-05-18T18:07:05"
     }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -29,7 +29,7 @@ class QueryTest(unittest.TestCase):
     def test_query_with_valid_pattern(self):
         q = self._client.query()
         q.pattern = "christmas"
-        self.assertIn("xmloutputversion=2", q.url())
+        self.assertIn("q=christmas", q.url())
 
     def test_query_without_valid_pattern(self):
         with self.assertRaises(twingly_search.TwinglySearchQueryException):
@@ -51,28 +51,28 @@ class QueryTest(unittest.TestCase):
         q = self._client.query()
         q.pattern = "spotify"
         q.language = "en"
-        self.assertEqual(q.request_parameters()['documentlang'], "en")
+        self.assertIn("lang:en", q.build_query_string())
 
     def test_query_should_add_start_date(self):
         q = self._client.query()
         q.search_query = "spotify"
         q.start_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
         query_string = q.build_query_string()
-        self.assertEqual(query_string, "spotify start-date: 2012-12-28T09:01:22Z")
+        self.assertEqual(query_string, "spotify start-date:2012-12-28T09:01:22Z")
 
     def test_query_should_add_end_date(self):
         q = self._client.query()
         q.search_query = "spotify"
         q.end_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
         query_string = q.build_query_string()
-        self.assertEqual(query_string, "spotify end-date: 2012-12-28T09:01:22Z")
+        self.assertEqual(query_string, "spotify end-date:2012-12-28T09:01:22Z")
 
     def test_query_should_add_lang(self):
         q = self._client.query()
         q.search_query = "spotify"
         q.language = "en"
         query_string = q.build_query_string()
-        self.assertEqual(query_string, "spotify lang: en")
+        self.assertEqual(query_string, "spotify lang:en")
 
     def test_query_should_build_query_string_with_deprecated_params(self):
         q = self._client.query()
@@ -82,7 +82,7 @@ class QueryTest(unittest.TestCase):
         q.end_time = self.datetime_with_timezone(datetime(2013, 12, 28, 9, 1, 22), "UTC")
         query_string = q.build_query_string()
         self.assertEqual(query_string,
-                         "spotify lang: en start-date: 2012-12-28T09:01:22Z end-date: 2013-12-28T09:01:22Z")
+                         "spotify lang:en start-date:2012-12-28T09:01:22Z end-date:2013-12-28T09:01:22Z")
 
     def test_query_should_build_query_string(self):
         q = self._client.query()
@@ -92,31 +92,31 @@ class QueryTest(unittest.TestCase):
         q.end_time = self.datetime_with_timezone(datetime(2013, 12, 28, 9, 1, 22), "UTC")
         query_string = q.build_query_string()
         self.assertEqual(query_string,
-                         "spotify lang: en start-date: 2012-12-28T09:01:22Z end-date: 2013-12-28T09:01:22Z")
+                         "spotify lang:en start-date:2012-12-28T09:01:22Z end-date:2013-12-28T09:01:22Z")
 
     def test_query_should_add_start_time(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.start_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
-        self.assertEqual(q.request_parameters()['ts'], "2012-12-28T09:01:22Z")
+        self.assertIn("start-date:2012-12-28T09:01:22Z", q.build_query_string())
 
     def test_query_using_start_time_without_timezone(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.start_time = datetime(2012, 12, 28, 9, 1, 22)
-        self.assertEqual(q.request_parameters()['ts'], "2012-12-28T09:01:22Z")
+        self.assertIn("start-date:2012-12-28T09:01:22Z", q.build_query_string())
 
     def test_query_using_start_time_with_timezone_other_than_utc(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.start_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "Europe/Stockholm")
-        self.assertEqual(q.request_parameters()['ts'], "2012-12-28T08:01:22Z")
+        self.assertIn("start-date:2012-12-28T08:01:22Z", q.build_query_string())
 
     def test_query_using_start_time_parsed_by_dateutil(self):
         q = self._client.query()
         q.pattern = "spotify"
-        q.end_time = dateutil.parser.parse("2012-12-28 09:01:22 -0800")
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T17:01:22Z")
+        q.start_time = dateutil.parser.parse("2012-12-28 09:01:22 -0800")
+        self.assertIn("start-date:2012-12-28T17:01:22Z", q.build_query_string())
 
     def test_query_when_start_time_is_not_a_datetime(self):
         q = self._client.query()
@@ -127,25 +127,25 @@ class QueryTest(unittest.TestCase):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T09:01:22Z")
+        self.assertIn("end-date:2012-12-28T09:01:22Z", q.build_query_string())
 
     def test_query_using_end_time_without_timezone(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = datetime(2012, 12, 28, 9, 1, 22)
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T09:01:22Z")
+        self.assertIn("end-date:2012-12-28T09:01:22Z", q.build_query_string())
 
     def test_query_using_end_time_with_timezone_other_than_utc(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "Europe/Stockholm")
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T08:01:22Z")
+        self.assertIn("end-date:2012-12-28T08:01:22Z", q.build_query_string())
 
     def test_query_using_end_time_parsed_by_dateutil(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = dateutil.parser.parse("2012-12-28 09:01:22 +0800")
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T01:01:22Z")
+        self.assertIn("2012-12-28T01:01:22Z", q.build_query_string())
 
     def test_query_when_end_time_is_not_a_datetime(self):
         q = self._client.query()
@@ -156,12 +156,12 @@ class QueryTest(unittest.TestCase):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
-        self.assertIn("tsTo=2012-12-28T09%3A01%3A22", q.url_parameters())
+        self.assertIn("end-date%3A2012-12-28T09%3A01%3A22Z", q.url_parameters())
 
     def test_query_pattern(self):
         q = self._client.query()
         q.pattern = "spotify"
-        self.assertIn("searchpattern=spotify", q.url_parameters())
+        self.assertIn("q=spotify", q.url_parameters())
 
     def test_query_when_searching_for_spotify(self):
         with Betamax(self._client._session).use_cassette('search_for_spotify_on_sv_blogs_from_query'):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -58,14 +58,14 @@ class QueryTest(unittest.TestCase):
         q.search_query = "spotify"
         q.start_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
         query_string = q.build_query_string()
-        self.assertEqual(query_string, "spotify start-date: 2012-12-28 09:01:22")
+        self.assertEqual(query_string, "spotify start-date: 2012-12-28T09:01:22Z")
 
     def test_query_should_add_end_date(self):
         q = self._client.query()
         q.search_query = "spotify"
         q.end_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
         query_string = q.build_query_string()
-        self.assertEqual(query_string, "spotify end-date: 2012-12-28 09:01:22")
+        self.assertEqual(query_string, "spotify end-date: 2012-12-28T09:01:22Z")
 
     def test_query_should_add_lang(self):
         q = self._client.query()
@@ -82,7 +82,7 @@ class QueryTest(unittest.TestCase):
         q.end_time = self.datetime_with_timezone(datetime(2013, 12, 28, 9, 1, 22), "UTC")
         query_string = q.build_query_string()
         self.assertEqual(query_string,
-                         "spotify lang: en start-date: 2012-12-28 09:01:22 end-date: 2013-12-28 09:01:22")
+                         "spotify lang: en start-date: 2012-12-28T09:01:22Z end-date: 2013-12-28T09:01:22Z")
 
     def test_query_should_build_query_string(self):
         q = self._client.query()
@@ -92,31 +92,31 @@ class QueryTest(unittest.TestCase):
         q.end_time = self.datetime_with_timezone(datetime(2013, 12, 28, 9, 1, 22), "UTC")
         query_string = q.build_query_string()
         self.assertEqual(query_string,
-                         "spotify lang: en start-date: 2012-12-28 09:01:22 end-date: 2013-12-28 09:01:22")
+                         "spotify lang: en start-date: 2012-12-28T09:01:22Z end-date: 2013-12-28T09:01:22Z")
 
     def test_query_should_add_start_time(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.start_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
-        self.assertEqual(q.request_parameters()['ts'], "2012-12-28 09:01:22")
+        self.assertEqual(q.request_parameters()['ts'], "2012-12-28T09:01:22Z")
 
     def test_query_using_start_time_without_timezone(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.start_time = datetime(2012, 12, 28, 9, 1, 22)
-        self.assertEqual(q.request_parameters()['ts'], "2012-12-28 09:01:22")
+        self.assertEqual(q.request_parameters()['ts'], "2012-12-28T09:01:22Z")
 
     def test_query_using_start_time_with_timezone_other_than_utc(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.start_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "Europe/Stockholm")
-        self.assertEqual(q.request_parameters()['ts'], "2012-12-28 08:01:22")
+        self.assertEqual(q.request_parameters()['ts'], "2012-12-28T08:01:22Z")
 
     def test_query_using_start_time_parsed_by_dateutil(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = dateutil.parser.parse("2012-12-28 09:01:22 -0800")
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28 17:01:22")
+        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T17:01:22Z")
 
     def test_query_when_start_time_is_not_a_datetime(self):
         q = self._client.query()
@@ -127,25 +127,25 @@ class QueryTest(unittest.TestCase):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28 09:01:22")
+        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T09:01:22Z")
 
     def test_query_using_end_time_without_timezone(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = datetime(2012, 12, 28, 9, 1, 22)
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28 09:01:22")
+        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T09:01:22Z")
 
     def test_query_using_end_time_with_timezone_other_than_utc(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "Europe/Stockholm")
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28 08:01:22")
+        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T08:01:22Z")
 
     def test_query_using_end_time_parsed_by_dateutil(self):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = dateutil.parser.parse("2012-12-28 09:01:22 +0800")
-        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28 01:01:22")
+        self.assertEqual(q.request_parameters()['tsTo'], "2012-12-28T01:01:22Z")
 
     def test_query_when_end_time_is_not_a_datetime(self):
         q = self._client.query()
@@ -156,7 +156,7 @@ class QueryTest(unittest.TestCase):
         q = self._client.query()
         q.pattern = "spotify"
         q.end_time = self.datetime_with_timezone(datetime(2012, 12, 28, 9, 1, 22), "UTC")
-        self.assertIn("tsTo=2012-12-28+09%3A01%3A22", q.url_parameters())
+        self.assertIn("tsTo=2012-12-28T09%3A01%3A22", q.url_parameters())
 
     def test_query_pattern(self):
         q = self._client.query()

--- a/twingly_search/__init__.py
+++ b/twingly_search/__init__.py
@@ -19,5 +19,4 @@ from .parser import Parser
 from .post import Post
 from .result import Result
 from .constants import TWINGLY_SEARCH_KEY
-from .constants import RESULT_DATE_TIME_FORMAT
-from .constants import QUERY_DATE_TIME_FORMAT
+from .constants import DATE_TIME_FORMAT

--- a/twingly_search/constants.py
+++ b/twingly_search/constants.py
@@ -2,5 +2,4 @@
 from __future__ import unicode_literals
 
 TWINGLY_SEARCH_KEY = 'TWINGLY_SEARCH_KEY'
-RESULT_DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
-QUERY_DATE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
+DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'

--- a/twingly_search/post.py
+++ b/twingly_search/post.py
@@ -8,7 +8,7 @@ import deprecation
 from pytz import utc
 
 import twingly_search
-from twingly_search.constants import RESULT_DATE_TIME_FORMAT
+from twingly_search.constants import DATE_TIME_FORMAT
 
 
 class Post(object):
@@ -113,7 +113,7 @@ class Post(object):
         self.coordinates = params.get("coordinates", "") or ""
 
     def _parse_time(self, time):
-        parsed_time = datetime.datetime.strptime(time, RESULT_DATE_TIME_FORMAT)
+        parsed_time = datetime.datetime.strptime(time, DATE_TIME_FORMAT)
         return utc.localize(parsed_time)
 
     def __unicode__(self):

--- a/twingly_search/query.py
+++ b/twingly_search/query.py
@@ -4,7 +4,7 @@ import deprecation
 from pytz import utc
 
 import twingly_search
-from twingly_search.constants import QUERY_DATE_TIME_FORMAT
+from twingly_search.constants import DATE_TIME_FORMAT
 from twingly_search.errors import TwinglySearchQueryException
 
 try:
@@ -153,7 +153,7 @@ class Query(object):
             return ''
 
         time_in_utc = self._time_to_utc(time)
-        result = time_in_utc.strftime(QUERY_DATE_TIME_FORMAT)
+        result = time_in_utc.strftime(DATE_TIME_FORMAT)
         return result
 
     def _time_to_utc(self, time):

--- a/twingly_search/query.py
+++ b/twingly_search/query.py
@@ -19,13 +19,13 @@ class Query(object):
     Twingly Search API Query
 
     Attributes:
-        pattern    (string) pattern the search query
-        language   (string) language which language to restrict the query to
-        client     (Client) the client that this query is connected to
-        start_time (datetime.datetime) search for posts published after this time (inclusive)
-                   Assumes UTC if the datetime object has no timezone set
-        end_time   (datetime.datetime) search for posts published before this time (inclusive)
-                   Assumes UTC if the datetime object has no timezone set
+        search_query (string) the search query
+        language     (string) which language to restrict the query to
+        client       (Client) the client that this query is connected to
+        start_time   (datetime.datetime) search for posts published after this time (inclusive)
+                     Assumes UTC if the datetime object has no timezone set
+        end_time     (datetime.datetime) search for posts published before this time (inclusive)
+                     Assumes UTC if the datetime object has no timezone set
     """
 
     def __init__(self, client):
@@ -76,13 +76,13 @@ class Query(object):
 
     @property
     @deprecation.deprecated(deprecated_in="3.0.0", removed_in="4.0.0", current_version=twingly_search.__version__,
-                            details="Language is part of Search pattern now. Use 'lang: value' in search pattern instead.")
+                            details="Language is part of search query now. Use 'lang:value' in search_query instead.")
     def language(self):
         return self._language
 
     @language.setter
     @deprecation.deprecated(deprecated_in="3.0.0", removed_in="4.0.0", current_version=twingly_search.__version__,
-                            details="Language is part of Search pattern now. Use 'lang: value' in search pattern instead.")
+                            details="Language is part of search query now. Use 'lang:value' in search_query instead.")
     def language(self, value):
         self._language = value
 
@@ -113,7 +113,7 @@ class Query(object):
         Executes the Query and returns the result
 
         :return: the Result for this query
-        :raises TwinglySearchQueryException: if pattern is empty
+        :raises TwinglySearchQueryException: if search_query is empty
         :raises TwinglySearchAuthenticationException: if the API couldn't authenticate you
             Make sure your API key is correct
         :raises TwinglySearchServerException: if the query could not be executed
@@ -134,7 +134,7 @@ class Query(object):
     def request_parameters(self):
         """
         :return: the request parameters
-        :raises TwinglySearchQueryException: if search query is empty
+        :raises TwinglySearchQueryException: if search_query is empty
         """
         if len(self.search_query) == 0:
             raise TwinglySearchQueryException("Missing search query")

--- a/twingly_search/query.py
+++ b/twingly_search/query.py
@@ -67,11 +67,11 @@ class Query(object):
         """
         full_search_query = self.search_query
         if self._language:
-            full_search_query += " lang: " + self._language
+            full_search_query += " lang:" + self._language
         if self.start_time:
-            full_search_query += " start-date: " + self._time_to_utc_string(self.start_time)
+            full_search_query += " start-date:" + self._time_to_utc_string(self.start_time)
         if self.end_time:
-            full_search_query += " end-date: " + self._time_to_utc_string(self.end_time)
+            full_search_query += " end-date:" + self._time_to_utc_string(self.end_time)
         return full_search_query
 
     @property
@@ -134,18 +134,14 @@ class Query(object):
     def request_parameters(self):
         """
         :return: the request parameters
-        :raises TwinglySearchQueryException: if pattern is empty
+        :raises TwinglySearchQueryException: if search query is empty
         """
         if len(self.search_query) == 0:
             raise TwinglySearchQueryException("Missing search query")
 
         return {
-            'key': self.client.api_key,
-            'searchpattern': self.search_query,
-            'documentlang': self.language,
-            'ts': self._time_to_utc_string(self.start_time),
-            'tsTo': self._time_to_utc_string(self.end_time),
-            'xmloutputversion': 2
+            'apikey': self.client.api_key,
+            'q': self.build_query_string()
         }
 
     def _time_to_utc_string(self, time):


### PR DESCRIPTION
* ISO8601 (`2017-01-01T00:00:00Z`) in query and result
* No space between operator and argument `start-date: 2017...` -> `start-date:2017...`
* Return the new (API v3) request parameters from `Query#request_parameters()`
* Stop using deprecated methods in the specs (except in the specs that tests the output from those methods :))