### PR TITLE
Test with Python 3.9-dev on Travis CI, drop 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9"
+  - "3.9-dev"
 install:
   - make cideps
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ dist: bionic
 language: python
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - make cideps
   - pip install .


### PR DESCRIPTION
3.5's EoL was 2020-09-30, see https://en.wikipedia.org/wiki/History_of_Python#Table_of_versions