### PR TITLE
Test against Python 3.9 instead of 3.9-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
 install:
   - make cideps
   - pip install .


### PR DESCRIPTION
Related to: https://github.com/twingly/twingly-search-api-python/issues/54

Close https://github.com/twingly/twingly-search-api-python/issues/54