### PR TITLE
Link to our new API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Build Status](https://github.com/twingly/twingly-search-api-python/workflows/CI/badge.svg?branch=master)](https://github.com/twingly/twingly-search-api-python/actions)
 
-A Python library for Twingly's Search API (previously known as Analytics API). Twingly is a blog search service that provides a searchable API known as [Twingly Search API](https://developer.twingly.com/resources/search/).
+A Python library for Twingly's Search API (previously known as Analytics API). Twingly is a blog search service that provides a searchable API known as [Twingly Search API][Twingly Search API documentation].
 
 ## Installation
 
@@ -45,7 +45,9 @@ Example code can be found in [examples/](examples/).
 
 The `twingly_search` library talks to a commercial blog search API and requires an API key. Best practice is to set the `TWINGLY_SEARCH_KEY` environment variable to the obtained key. `twingly_search.Client` can be passed a key at initialization if your setup does not allow environment variables.
 
-To learn more about the capabilities of the API, please read the [Twingly Search API documentation](https://developer.twingly.com/resources/search/).
+To learn more about the capabilities of the API, please read the [Twingly Search API documentation].
+
+[Twingly Search API documentation]: https://app.twingly.com/blog_search?tab=documentation
 
 ### Documentation
 

--- a/examples/search_using_local_timezone.py
+++ b/examples/search_using_local_timezone.py
@@ -33,7 +33,7 @@ class SimpleSearchCli(object):
         self.client = twingly_search.Client()
 
     def start(self):
-        # See https://developer.twingly.com/resources/search-language/
+        # See https://app.twingly.com/blog_search?tab=documentation
         q = self.client.query()
         q.search_query = raw_input("What do you want to search for? ")
         q.start_time = self._read_time_from_stdin("Start time")

--- a/twingly_search/post.py
+++ b/twingly_search/post.py
@@ -28,14 +28,14 @@ class Post(object):
         blog_url      (string) the blog URL
         blog_name     (string) name of the blog
         blog_rank     (int) the rank of the blog, based on authority and language
-                      (https://developer.twingly.com/resources/search/#authority)
+                      (https://app.twingly.com/blog_search?tab=documentation)
         blog_id       (string) the ID of the blog
         authority     (int) the blog's authority/influence
-                      (https://developer.twingly.com/resources/search/#authority)
+                      (https://app.twingly.com/blog_search?tab=documentation)
         tags          (list of string) tags
         id            (string) the post ID
         location_code (string) ISO two letter location code
-                      (https://developer.twingly.com/resources/search-language/#supported-locations)
+                      (https://app.twingly.com/blog_search?tab=documentation)
         inlinks_count (int) amount of the inlinks
         reindexed_at  (datetime.datetime) the time, in UTC, when this post was re-indexed by Twingly
         links         (list of string) links


### PR DESCRIPTION
As the old site, developer.twingly.com, has been shut down. The documentation for all of our APIs are now available (behind login) at https://app.twingly.com instead.

I didn't link to the specific documentation sections in the code, just so we don't need to update the links in case we restructure the documentation in the future.