### PR TITLE
Run CI on latest versions of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python: [3.8, 3.9, '3.10', 3.11, 3.12]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
These are the currently active versions of Python. See https://devguide.python.org/versions/.